### PR TITLE
Update wallet.sol following best practice

### DIFF
--- a/backend-solidity/contracts/wallet.sol
+++ b/backend-solidity/contracts/wallet.sol
@@ -11,8 +11,9 @@ contract wallet{
     TransactionDetails[] public transferDetails;
     
     //functions
-    function sendEth(address senderAddress) public payable {
-        payable(senderAddress).transfer(msg.value);
+    function sendEth(address payable senderAddress) public payable {
+        (bool sent, bytes memory data) = senderAddress.call{value: msg.value}("");
+        require(sent, "Failed to send Ether");
     }
     function VIEWFUNCTION() public view returns(uint256){
         return (10);


### PR DESCRIPTION
Used call function instead of the transfer function to transfer ETH. The call function is often preferred over the transfer function due to its flexibility and error-handling capabilities.